### PR TITLE
Fixed bug causing airstuck

### DIFF
--- a/SM-ViewAngle-Fix.sp
+++ b/SM-ViewAngle-Fix.sp
@@ -27,11 +27,6 @@ new Float:oldpos[3];
 public Action:OnPlayerRunCmd(client, &buttons, &impulse, Float:vel[3], Float:angles[3], &weapon, &subtype, &cmdnum, &tickcount, &seed, mouse[2])
 {
 	new bool:alive = IsPlayerAlive(client);
-
-	if (cmdnum <= 0)
-	{
-		return Plugin_Handled;
-	}
 	
 	if(!alive)
 	{


### PR DESCRIPTION
Removed cmdnum check and the subsequent Plugin_Handled call as to remove the ability for players to airstuck.

The recent "airstuck bug" is caused by this plugin not letting the server fully run the command for the player in question when the player sets their cmdnum to 0.